### PR TITLE
fix: 修复右键菜单在路由切换后残留的问题 #9

### DIFF
--- a/content.js
+++ b/content.js
@@ -283,6 +283,16 @@
 
   const applyTheme = () => {
     const enabled = currentConfig.enabled && !isExcludedRoute();
+
+    //插件禁用时清理
+    if (!enabled) {
+      document.querySelectorAll(".context-menu").forEach((menu) => {
+        if (menu.parentElement === document.body) {
+          menu.remove();
+        }
+      });
+    }
+
     document.documentElement.classList.toggle(ENABLED_CLASS, enabled);
     const mode = syncLayoutMode(enabled);
 
@@ -346,6 +356,12 @@
   });
 
   window.addEventListener("hashchange", () => {
+    //路由切换同步清理
+    document.querySelectorAll(".context-menu").forEach((menu) => {
+      if (menu.parentElement === document.body) {
+        menu.remove();
+      }
+    });
     scheduleApply();
     window.setTimeout(scheduleApply, 0);
   }, { passive: true });
@@ -360,6 +376,12 @@
     const target = event.target;
     if (!(target instanceof Element)) return;
     if (!target.closest("header .nav-links a, .profile-menu a, .mk-apple-side-link, .side-navigation a, .side-profile-menu a, .side-profile-menu-button, .side-action-button")) return;
+    //导航点击时清理
+    document.querySelectorAll(".context-menu").forEach((menu) => {
+      if (menu.parentElement === document.body) {
+        menu.remove();
+      }
+    });
     window.setTimeout(scheduleApply, 0);
   }, true);
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Apple Music 主题",
   "plugin_id": "apple-music-theme",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "minversion": "1.6.6",
   "moekoe": true,
   "author": {


### PR DESCRIPTION
## 概述
syncFloatingContextMenus 将 .context-menu 移到 document.body 后脱离了路由组件生命周期，页面切换时 DOM 销毁无法清理。 
在hashchange /导航 click / applyTheme 三处同步移除 body 下的残留菜单。

## 详细描述

### 问题描述
#### 使用 Apple Music 主题 后歌曲的右键菜单可同时存在多个 #9

### 触发流程
音乐库->我喜欢->任选一首歌，对其右键->在菜单存在的情况下，点击音乐库->可看到菜单仍然存在

### 原因分析
插件 syncFloatingContextMenus()（content.js L220-232）将 .context-menu 从其原始父节点通过 appendChild 移动到 document.body，并设为 position: fixed：
```
if (menu.parentElement !== document.body) {
  document.body.appendChild(menu);
}
```
MoeKoeMusic 原生行为：右键菜单在路由组件内部创建，路由切换时组件 DOM 被销毁，菜单随之消失。插件将其移出组件树后，菜单脱离了路由组件的生命周期，hashchange 触发的 DOM 销毁无法覆盖到 body 下的菜单节点，导致残留。

### 修复方案
在三处路由切换入口同步立即清除 body 下的残留 .context-menu（使用同步 forEach + remove()，不依赖 requestAnimationFrame，确保在 syncFloatingContextMenus 再次将菜单移入 body 之前完成清理）

### 测试
已在win11上进行测试，测试结果为问题已修复